### PR TITLE
Added pagination handling to getAll method of DocumentManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-dropbox-paper",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A source plugin for Gatsby that pulls data from the Dropbox Paper API.",
   "main": "gatsby-node.js",
   "scripts": {


### PR DESCRIPTION
Hi there,

Hoping to make a contribution by adding pagination handling. It looks like the default limit on the paper api's documents/list endpoint is 1000 documents, after which pagination occurs. Hopefully these changes look good, let me know what you think.

Thanks,

James