### PR TITLE
Adding retry mechanism for request failures

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ plugins: [
         options: {
             access_token: "your-access-token",
             format: "html"
+        }
     },
 },
 ```
@@ -99,11 +100,30 @@ Using the [gatsby-transformer-remark](https://www.gatsbyjs.org/packages/gatsby-t
 }
 ```
 
+### Configuring Retries On Failure
+
+The Dropbox Paper API is not always responsive when requesting a document's metadata or the HTML and markdown. This plugin now supports configurable retrying with a modifiable delay:
+
+```js
+plugins: [
+    {
+        resolve: "gatsby-source-dropbox-paper",
+        options: {
+            access_token: "your-access-token",
+            format: "html",
+            maxRetryCount: 3, //defaults to 5 retries per API request
+            retryDelayMs: 100, //defaults to 0
+            shouldRetry: true //defaults to false, needs to be true for the prior two options to work
+        }
+    },
+},
+```
+
 ## The Future
 
 Right now, this plugin pulls _all_ documents from an authenticated account, which is less than ideal. Improvements will come with changes to this plugin, as well as the evolution of the [Dropbox API](https://www.dropbox.com/developers), which has limited capabilities in terms of filtering documents to be pulled. Here's what I'd like to see in the future:
 
-- The ability pull documents by status.
+- The ability to pull documents by status.
 - The ability to pull documents by specific directory.
 - Other stuff.
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,18 +1,24 @@
 const DocumentManager = require('./DocumentManager')
 
 exports.sourceNodes = async (
-  { actions, cache, createContentDigest },
+  { actions, cache, createContentDigest, reporter },
   configOptions
 ) => {
   const { createNode, touchNode } = actions
   delete configOptions.plugins
   const format = configOptions.format ? configOptions.format : 'markdown'
+  const {
+    maxRetryCount = 4,
+    retryDelayMs = 0,
+    shouldRetry = false,
+  } = configOptions
   const documentManager = new DocumentManager(
     configOptions.access_token,
-    format
+    format,
+    { maxRetryCount, retryDelayMs, shouldRetry }
   )
 
-  console.log('\nPulling data from Dropbox Paper...\n')
+  reporter.info('Pulling data from Dropbox Paper...')
 
   for (let id of await documentManager.getAll()) {
     let meta = await documentManager.getMeta(id)
@@ -59,7 +65,7 @@ exports.sourceNodes = async (
     }
   }
 
-  console.log(
-    '\nThanks for using the gatsby-source-dropbox-paper plugin. Help make it better by contributing here: https://github.com/alexmacarthur/gatsby-source-dropbox-paper\n'
+  reporter.info(
+    'Thanks for using the gatsby-source-dropbox-paper plugin. Help make it better by contributing here: \nhttps://github.com/alexmacarthur/gatsby-source-dropbox-paper'
   )
 }


### PR DESCRIPTION
* Added retry mechanism, updated Readme with documentation
* updated `console.log` statements to make use of the Gatsby logger
* added `.prettierrc` file, as some of the conventions used in formatting this project make use of non-standard prettier options

@alexmacarthur I've noticed that the Dropbox Paper API periodically experiences outages/depending on the server that serves your request: intermittent 500 responses get returned instead of the document metadata/downloaded content. This can spell doom for automated deployments; at first I tried simply adding a delay to each request, but the issue is tied more to the server's themselves being occasionally unresponsive than it is to the number of requests being made, necessitating retrying of the requests that fail. 

I've tested these changes locally using my blog with a large number of Dropbox Paper documents, but by no means do I think what I've done is perfect.  I didn't increment the version number in `package.json`, either ... I wanted to wait for your feedback/see if you preferred to do that. Looking forward to hearing from you!